### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,7 @@
             "querystring": ["client_id"]
           },
           "client_secret": {
-            "querystring": ["client_id"]
+            "querystring": ["client_secret"]
           }
         }
       },

--- a/manifest.json
+++ b/manifest.json
@@ -57,12 +57,21 @@
       {
         "url": "https://app.productboard.com/.*",
         "methods": ["GET", "POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "querystring": ["client_id"]
+          },
+          "client_secret": {
+            "querystring": ["client_id"]
+          }
+        }
       },
       {
         "url": "https://api.productboard.com/.*",
         "methods": ["GET", "POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {}
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the `manifest.json` configuration to support new settings injection for Productboard API calls. The main change is the addition of a `settingsInjection` field to allow dynamic injection of authentication parameters via query string.

API configuration enhancements:

* Added a `settingsInjection` field to the Productboard web app endpoint configuration, enabling injection of `client_id` and `client_secret` values from the query string for improved authentication handling.
* Added an empty `settingsInjection` object to the Productboard API endpoint configuration to maintain consistency in the manifest structure.